### PR TITLE
feat: add support for Mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 The Jembi MPI, also known as JeMPI, is a standards-based client registry (CR) or master patient index (MPI). JeMPI facilitates the exchange of patient information between different systems and holds patient identifiers that may include patient demographic information. This is a necessary tool for public health to help manage patients, monitor outcomes, and conduct case-based surveillance. JeMPI’s primary goal is to act as a tool in order to solve the issue of multiple or duplicated patient records that are submitted from multiple point of service systems such as electronic medical records, lab systems, radiology systems and other health information systems. This is achieved by matching the various patient records from different systems under a Master Patient record with a unique ID. This allows for downstream applications, such as surveillance, to accurately display data and information on patient records without the worry that the data contains multiple records for the same patient.
 
-### Requirements
-- linux (bash)
+## Requirements
+- linux (bash >= 4.x)
   - docker (non-root)
   - maven
   - sbt
@@ -14,7 +14,7 @@ The Jembi MPI, also known as JeMPI, is a standards-based client registry (CR) or
     - wxpython
     - requests
 
-### Installation
+## Installation
 - Directory structure
   - \<base>
     - JeMPI           - ```git@github.com:jembi/JeMPI.git```
@@ -34,5 +34,34 @@ The Jembi MPI, also known as JeMPI, is a standards-based client registry (CR) or
      4. ```./c-registry-2-push-hub-images.sh```
      5. ```./z-stack-3-build-reboot.sh```
 
-# Development
-It's possible to run the whole stack local without having to use a local registry using the command : `./launch-local.sh`
+## Development
+It's possible to run the whole stack local without having to use a local registry using the command : 
+```
+./launch-local.sh
+```
+In order to remove the stack, you could use the following command :
+```
+docker stack remove jempi
+```
+
+## Support for Mac OS
+
+For MacOS users, the `envsubst` command will fail, so you'll need to add it  :
+```
+brew install gettext
+brew link --force gettext 
+```
+
+Other bash commands may fail (such as "declare -A"). So you may want to update bash >=v4:
+```
+brew install bash
+bash --version
+``` 
+
+Then to run the stack locally, you will need to switch to bash first :
+```
+bash ./launch-local.sh
+```
+
+Note that currently, there is no Dgraph Ratel docker image compiled for M1 CPU, so most certainly you would run into a "Unsupported platform" error. For this you could either decide not to run the Ratel service by setting `export SCALE_RATEL=0` in `docker/conf/env/create-env-linux-1.sh` and use [https://play.dgraph.io/](https://play.dgraph.io/) instead.
+

--- a/docker/b-swarm-1-init-node1.sh
+++ b/docker/b-swarm-1-init-node1.sh
@@ -6,6 +6,10 @@ set -u
 source ./0-conf.env
 
 docker swarm init --advertise-addr $NODE1_IP
+# Get current node ID and set the label (for later use by the deployment contraints)
+SELF_NODE_ID=$(docker node inspect self | grep -i -E -o '"ID": "([a-z0-9]+)"' | rev | cut -c 2- | rev | cut -c 8)
+docker node update --label-add name=${NODE1} ${SELF_NODE_ID} 
+
 echo
 
 WORKER_TOKEN=$(docker swarm join-token worker --quiet)

--- a/docker/conf/env/create-env-linux-1.sh
+++ b/docker/conf/env/create-env-linux-1.sh
@@ -6,8 +6,15 @@ export PROJECT_DATA_DIR=${PROJECT_DIR}/docker_data/data
 export PROJECT_DATA_APPS_DIR=${PROJECT_DIR}/docker_data/data-apps
 export PROJECT_DATA_MONITOR_DIR=${PROJECT_DIR}/docker_data/data-monitor
 
-export NODE1=$(hostname)
-export NODE1_IP=$(hostname -i | cut -d ' ' -f1)
+if [ $USE_LOCAL_REGISTRY == 'true' ]; then
+    # In cluster mode, we set the network ip address
+    export NODE1=$(hostname)
+    export NODE1_IP=$(ifconfig | grep -E "([0-9]{1,3}\.){3}[0-9]{1,3}" | grep -v 127.0.0.1 | head -1 | awk '{ print $2 }')
+else
+    # For local deployments (single mode), we set localhost IP
+    export NODE1="node-1"
+    export NODE1_IP="127.0.0.1"
+fi
 
 export SCALE_KAFKA_01=1
 export SCALE_KAFKA_02=1

--- a/docker/conf/stack/docker-stack-0.yml
+++ b/docker/conf/stack/docker-stack-0.yml
@@ -54,7 +54,7 @@ services:
         condition: on-failure
       placement:
         constraints:
-          - node.hostname == $PLACEMENT_KAFKA_01
+          - node.labels.name == $PLACEMENT_KAFKA_01
   
   kafka-02:
     image: ${IMAGE_REGISTRY}$KAFKA_IMAGE 
@@ -90,7 +90,7 @@ services:
         condition: on-failure
       placement:
         constraints:
-          - node.hostname == $PLACEMENT_KAFKA_02
+          - node.labels.name == $PLACEMENT_KAFKA_02
   
   kafka-03:
     image: ${IMAGE_REGISTRY}$KAFKA_IMAGE 
@@ -126,7 +126,7 @@ services:
         condition: on-failure
       placement:
         constraints:
-          - node.hostname == $PLACEMENT_KAFKA_03
+          - node.labels.name == $PLACEMENT_KAFKA_03
 
   zero-01:
     image: ${IMAGE_REGISTRY}${DGRAPH_IMAGE}
@@ -155,7 +155,7 @@ services:
         condition: on-failure
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_DGRAPH_ZERO_01}
+        - node.labels.name == ${PLACEMENT_DGRAPH_ZERO_01}
     command: dgraph zero --my=zero-01:5080 --replicas 1
 
   alpha-01:
@@ -185,7 +185,7 @@ services:
         condition: on-failure
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_DGRAPH_ALPHA_01}
+        - node.labels.name == ${PLACEMENT_DGRAPH_ALPHA_01}
     command: dgraph alpha --my=alpha-01:7080 --zero=zero-01:5080 --security whitelist=0.0.0.0/0 --telemetry "sentry=false;"
 
   alpha-02:
@@ -215,7 +215,7 @@ services:
         condition: on-failure
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_DGRAPH_ALPHA_02}
+        - node.labels.name == ${PLACEMENT_DGRAPH_ALPHA_02}
     command: dgraph alpha --my=alpha-02:7081 --zero=zero-01:5080 --security whitelist=0.0.0.0/0 -o 1 --telemetry "sentry=false;"
 
   alpha-03:
@@ -245,7 +245,7 @@ services:
         condition: on-failure
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_DGRAPH_ALPHA_03}
+        - node.labels.name == ${PLACEMENT_DGRAPH_ALPHA_03}
     command: dgraph alpha --my=alpha-03:7082 --zero=zero-01:5080 --security whitelist=0.0.0.0/0 -o 2 --telemetry "sentry=false;"
 
   ratel:
@@ -266,7 +266,7 @@ services:
         condition: on-failure
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_RATEL}
+        - node.labels.name == ${PLACEMENT_RATEL}
     command: dgraph-ratel
 
   postgresql:
@@ -299,7 +299,7 @@ services:
         max_attempts: 0
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_POSTGRESQL}
+        - node.labels.name == ${PLACEMENT_POSTGRESQL}
 
 
   async-receiver:
@@ -331,7 +331,7 @@ services:
         max_attempts: 0
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_ASYNC_RECEIVER}
+        - node.labels.name == ${PLACEMENT_ASYNC_RECEIVER}
 
   sync-receiver:
     image: ${IMAGE_REGISTRY}${SYNC_RECEIVER_IMAGE}
@@ -363,7 +363,7 @@ services:
         max_attempts: 0
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_SYNC_RECEIVER}
+        - node.labels.name == ${PLACEMENT_SYNC_RECEIVER}
 
   etl:
     image: ${IMAGE_REGISTRY}${ETL_IMAGE}
@@ -390,7 +390,7 @@ services:
         max_attempts: 0
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_ETL}
+        - node.labels.name == ${PLACEMENT_ETL}
 
   controller:
     image: ${IMAGE_REGISTRY}${CONTROLLER_IMAGE}
@@ -422,7 +422,7 @@ services:
         max_attempts: 0
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_CONTROLLER}
+        - node.labels.name == ${PLACEMENT_CONTROLLER}
        
   em:
     image: ${IMAGE_REGISTRY}${EM_IMAGE}
@@ -449,7 +449,7 @@ services:
         max_attempts: 0
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_EM}
+        - node.labels.name == ${PLACEMENT_EM}
 
   linker:
     image: ${IMAGE_REGISTRY}${LINKER_IMAGE}
@@ -477,7 +477,7 @@ services:
         max_attempts: 0
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_LINKER}
+        - node.labels.name == ${PLACEMENT_LINKER}
 
   api:
     image: ${IMAGE_REGISTRY}${API_IMAGE}
@@ -524,5 +524,5 @@ services:
         max_attempts: 0
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_API}
+        - node.labels.name == ${PLACEMENT_API}
     

--- a/docker/conf/stack/docker-stack-1.yml
+++ b/docker/conf/stack/docker-stack-1.yml
@@ -54,7 +54,7 @@ services:
         condition: on-failure
       placement:
         constraints:
-          - node.hostname == $PLACEMENT_KAFKA_01
+          - node.labels.name == $PLACEMENT_KAFKA_01
   
   kafka-02:
     image: ${IMAGE_REGISTRY}$KAFKA_IMAGE 
@@ -90,7 +90,7 @@ services:
         condition: on-failure
       placement:
         constraints:
-          - node.hostname == $PLACEMENT_KAFKA_02
+          - node.labels.name == $PLACEMENT_KAFKA_02
   
   kafka-03:
     image: ${IMAGE_REGISTRY}$KAFKA_IMAGE 
@@ -126,7 +126,7 @@ services:
         condition: on-failure
       placement:
         constraints:
-          - node.hostname == $PLACEMENT_KAFKA_03
+          - node.labels.name == $PLACEMENT_KAFKA_03
 
   zero-01:
     image: ${IMAGE_REGISTRY}${DGRAPH_IMAGE}
@@ -155,7 +155,7 @@ services:
         condition: on-failure
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_DGRAPH_ZERO_01}
+        - node.labels.name == ${PLACEMENT_DGRAPH_ZERO_01}
     command: dgraph zero --my=zero-01:5080 --replicas 1
 
   alpha-01:
@@ -185,7 +185,7 @@ services:
         condition: on-failure
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_DGRAPH_ALPHA_01}
+        - node.labels.name == ${PLACEMENT_DGRAPH_ALPHA_01}
     command: dgraph alpha --my=alpha-01:7080 --zero=zero-01:5080 --security whitelist=0.0.0.0/0 --telemetry "sentry=false;"
 
   alpha-02:
@@ -215,7 +215,7 @@ services:
         condition: on-failure
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_DGRAPH_ALPHA_02}
+        - node.labels.name == ${PLACEMENT_DGRAPH_ALPHA_02}
     command: dgraph alpha --my=alpha-02:7081 --zero=zero-01:5080 --security whitelist=0.0.0.0/0 -o 1 --telemetry "sentry=false;"
 
   alpha-03:
@@ -245,7 +245,7 @@ services:
         condition: on-failure
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_DGRAPH_ALPHA_03}
+        - node.labels.name == ${PLACEMENT_DGRAPH_ALPHA_03}
     command: dgraph alpha --my=alpha-03:7082 --zero=zero-01:5080 --security whitelist=0.0.0.0/0 -o 2 --telemetry "sentry=false;"
 
   ratel:
@@ -266,7 +266,7 @@ services:
         condition: on-failure
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_RATEL}
+        - node.labels.name == ${PLACEMENT_RATEL}
     command: dgraph-ratel
 
   postgresql:
@@ -299,7 +299,7 @@ services:
         max_attempts: 0
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_POSTGRESQL}
+        - node.labels.name == ${PLACEMENT_POSTGRESQL}
 
 
   async-receiver:
@@ -331,7 +331,7 @@ services:
         max_attempts: 0
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_ASYNC_RECEIVER}
+        - node.labels.name == ${PLACEMENT_ASYNC_RECEIVER}
 
   sync-receiver:
     image: ${IMAGE_REGISTRY}${SYNC_RECEIVER_IMAGE}
@@ -363,7 +363,7 @@ services:
         max_attempts: 0
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_SYNC_RECEIVER}
+        - node.labels.name == ${PLACEMENT_SYNC_RECEIVER}
 
   etl:
     image: ${IMAGE_REGISTRY}${ETL_IMAGE}
@@ -390,7 +390,7 @@ services:
         max_attempts: 0
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_ETL}
+        - node.labels.name == ${PLACEMENT_ETL}
 
   controller:
     image: ${IMAGE_REGISTRY}${CONTROLLER_IMAGE}
@@ -422,7 +422,7 @@ services:
         max_attempts: 0
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_CONTROLLER}
+        - node.labels.name == ${PLACEMENT_CONTROLLER}
        
   em:
     image: ${IMAGE_REGISTRY}${EM_IMAGE}
@@ -449,7 +449,7 @@ services:
         max_attempts: 0
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_EM}
+        - node.labels.name == ${PLACEMENT_EM}
 
   linker:
     image: ${IMAGE_REGISTRY}${LINKER_IMAGE}
@@ -477,7 +477,7 @@ services:
         max_attempts: 0
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_LINKER}
+        - node.labels.name == ${PLACEMENT_LINKER}
 
   api:
     image: ${IMAGE_REGISTRY}${API_IMAGE}
@@ -524,5 +524,5 @@ services:
         max_attempts: 0
       placement:
         constraints:
-        - node.hostname == ${PLACEMENT_API}
+        - node.labels.name == ${PLACEMENT_API}
     

--- a/docker/helper/scripts/c-registry-3-build-push-app-images.sh
+++ b/docker/helper/scripts/c-registry-3-build-push-app-images.sh
@@ -10,7 +10,7 @@ pushd .
   pwd
   source ./0-conf.env
   pushd ../JeMPI_Apps/JeMPI_Build
-    ./build-all.sh
+    source ./build-all.sh
   popd
 
 popd

--- a/docker/helper/scripts/d-stack-03-up-hub-containers.sh
+++ b/docker/helper/scripts/d-stack-03-up-hub-containers.sh
@@ -22,10 +22,10 @@ pushd .
   docker service scale ${STACK_NAME}_postgresql=${SCALE_POSTGRESQL}
 
   pushd helper/topics
-    ./topics-create.sh
-    ./topics-list.sh
+    source ./topics-create.sh
+    source ./topics-list.sh
   popd
   pushd helper/postgres
-    ./create-schema.sh
+    source ./create-schema.sh
   popd
 popd

--- a/docker/helper/scripts/e-tools-02-list-topics.sh
+++ b/docker/helper/scripts/e-tools-02-list-topics.sh
@@ -9,6 +9,6 @@ pushd .
 
   echo Check it
 
-  ./helper/topics/topics-list.sh
+  source ./helper/topics/topics-list.sh
 
 popd

--- a/docker/helper/scripts/e-tools-03-describe-topics.sh
+++ b/docker/helper/scripts/e-tools-03-describe-topics.sh
@@ -8,6 +8,6 @@ pushd .
   cd ${SCRIPT_DIR}/../..
 
   echo Describe it
-  ./helper/topics/topics-describe.sh
+  source ./helper/topics/topics-describe.sh
 
 popd  

--- a/docker/helper/topics/topics-config.sh
+++ b/docker/helper/topics/topics-config.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 TOPIC_PATIENT_ASYNC_ETL="JeMPI-async-etl"
 TOPIC_PATIENT_CONTROLLER="JeMPI-patient-controller"

--- a/docker/z-stack-1-build.sh
+++ b/docker/z-stack-1-build.sh
@@ -8,10 +8,10 @@ set -u
 #./helper/scripts/d-stack-08-rm.sh
 
 echo
-echo Build Apps
+echo "Build Apps"
 pwd
 pushd ../JeMPI_Apps
-  ./build-all.sh
+  source ./build-all.sh
 popd
 #./helper/scripts/c-registry-3-build-push-app-images.sh
 

--- a/docker/z-stack-2-reboot.sh
+++ b/docker/z-stack-2-reboot.sh
@@ -4,17 +4,17 @@ set -e
 set -u
 
 echo
-echo Down stack
-./helper/scripts/d-stack-08-rm.sh
-./helper/scripts/d-stack-09-wait-removed.sh
+echo "Down stack"
+source ./helper/scripts/d-stack-08-rm.sh
+source ./helper/scripts/d-stack-09-wait-removed.sh
 
 echo
-echo Up app containers
-./helper/scripts/d-stack-01-create-dirs.sh
+echo "Up app containers"
+source ./helper/scripts/d-stack-01-create-dirs.sh
 sleep 2
-./helper/scripts/d-stack-02-deploy-0.sh
+source ./helper/scripts/d-stack-02-deploy-0.sh
 sleep 2
-./helper/scripts/d-stack-03-up-hub-containers.sh
+source ./helper/scripts/d-stack-03-up-hub-containers.sh
 sleep 2
-./helper/scripts/d-stack-04-up-app-containers.sh
+source ./helper/scripts/d-stack-04-up-app-containers.sh
 

--- a/docker/z-stack-3-build-reboot.sh
+++ b/docker/z-stack-3-build-reboot.sh
@@ -4,14 +4,14 @@ set -e
 set -u
 
 echo
-echo Down stacks
-./helper/scripts/d-stack-08-rm.sh
+echo "Down stacks"
+source ./helper/scripts/d-stack-08-rm.sh
 
 echo
-echo Build Apps
+echo "Build Apps"
 pwd
 pushd ../JeMPI_Apps
-  ./build-all.sh
+  source ./build-all.sh
 popd
 #./helper/scripts/c-registry-3-build-push-app-images.sh
 sleep 2
@@ -19,11 +19,10 @@ sleep 2
 echo
 echo Up app containers
 #./helper/scripts/d-stack-09-wait-removed.sh
-./helper/scripts/d-stack-01-create-dirs.sh
+source ./helper/scripts/d-stack-01-create-dirs.sh
 sleep 2
-./helper/scripts/d-stack-02-deploy-0.sh
+source ./helper/scripts/d-stack-02-deploy-0.sh
 sleep 2
-./helper/scripts/d-stack-03-up-hub-containers.sh
+source ./helper/scripts/d-stack-03-up-hub-containers.sh
 sleep 2
-./helper/scripts/d-stack-04-up-app-containers.sh
-
+source ./helper/scripts/d-stack-04-up-app-containers.sh


### PR DESCRIPTION
## Motivation
It's possible with this PR to run JeMPI on a Mac device except for ratel service (UI for Dgraph), it seems there no docker image available for M1 CPU. The solution is to disable Ratel service by setting `export SCALE_RATEL=0` in `./docker/conf/env` and use https://play.dgraph.io/ instead.

Another thing that the PR addresses is the docker deployment constraints which tests on the docker node hostname. For Windows and Mac, the docker node hostname is "docker-desktop" and does not pick up the machine hostname. So we have to switch that to a label check in the docker compose files :

Example :
```
placement:
        constraints:
          - node.labels.name == ${PLACEMENT_DGRAPH_ALPHA_03}
```