### PR TITLE
add missing env variable for kafka servers

### DIFF
--- a/docker/conf/stack/docker-stack-high-0.yml
+++ b/docker/conf/stack/docker-stack-high-0.yml
@@ -339,6 +339,8 @@ services:
 
   async-receiver:
     image: ${IMAGE_REGISTRY}${ASYNC_RECEIVER_IMAGE}
+    environment:
+      KAFKA_SERVERS: ${KAFKA_SERVERS}
     networks:
     - backend-kafka
     volumes:
@@ -366,6 +368,8 @@ services:
 
   etl:
     image: ${IMAGE_REGISTRY}${ETL_IMAGE}
+    environment:
+      KAFKA_SERVERS: ${KAFKA_SERVERS}
     networks:
     - backend-kafka
     volumes:
@@ -389,6 +393,8 @@ services:
 
   controller:
     image: ${IMAGE_REGISTRY}${CONTROLLER_IMAGE}
+    environment:
+      KAFKA_SERVERS: ${KAFKA_SERVERS}
     networks:
     - backend-kafka
     ports:
@@ -417,6 +423,8 @@ services:
        
   em:
     image: ${IMAGE_REGISTRY}${EM_IMAGE}
+    environment:
+      KAFKA_SERVERS: ${KAFKA_SERVERS}
     networks:
     - backend-kafka
     volumes:

--- a/docker/conf/stack/docker-stack-high-1.yml
+++ b/docker/conf/stack/docker-stack-high-1.yml
@@ -339,6 +339,8 @@ services:
 
   async-receiver:
     image: ${IMAGE_REGISTRY}${ASYNC_RECEIVER_IMAGE}
+    environment:
+      KAFKA_SERVERS: ${KAFKA_SERVERS}
     networks:
     - backend-kafka
     volumes:
@@ -366,6 +368,8 @@ services:
 
   etl:
     image: ${IMAGE_REGISTRY}${ETL_IMAGE}
+    environment:
+      KAFKA_SERVERS: ${KAFKA_SERVERS}
     networks:
     - backend-kafka
     volumes:
@@ -389,6 +393,8 @@ services:
 
   controller:
     image: ${IMAGE_REGISTRY}${CONTROLLER_IMAGE}
+    environment:
+      KAFKA_SERVERS: ${KAFKA_SERVERS}
     networks:
     - backend-kafka
     ports:
@@ -417,6 +423,8 @@ services:
        
   em:
     image: ${IMAGE_REGISTRY}${EM_IMAGE}
+    environment:
+      KAFKA_SERVERS: ${KAFKA_SERVERS}
     networks:
     - backend-kafka
     volumes:


### PR DESCRIPTION
- add the missing KAFAK-SERVERS variable to the create-env-high config