### PR TITLE
Updating docker stack to include new kafka properties

### DIFF
--- a/devops/linux/docker/conf/stack/docker-stack-high-0.yml
+++ b/devops/linux/docker/conf/stack/docker-stack-high-0.yml
@@ -107,6 +107,10 @@ services:
       KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_CFG_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_CFG_BROKER_ID: 1
+    # TODO - Later: Research on the appropriate sizes to use for each of these properties. Were added in https://github.com/bitnami/containers/commit/a2984c22221afa766cbf501c30f96a7dc6058653 as a port
+      KAFKA_CFG_MAX_REQUEST_SIZE: 2000000
+      KAFKA_CFG_MESSAGE_MAX_BYTES: 2000000
+      KAFKA_CFG_MAX_PARTITION_FETCH_BYTES: 2000000
     volumes:
       - type: bind
         source: ${DATA_KAFKA_01_DIR}

--- a/devops/linux/docker/conf/stack/docker-stack-high-0.yml
+++ b/devops/linux/docker/conf/stack/docker-stack-high-0.yml
@@ -107,10 +107,7 @@ services:
       KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_CFG_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_CFG_BROKER_ID: 1
-    # TODO - Later: Research on the appropriate sizes to use for each of these properties. Were added in https://github.com/bitnami/containers/commit/a2984c22221afa766cbf501c30f96a7dc6058653 as a port
-      KAFKA_CFG_MAX_REQUEST_SIZE: 2000000
-      KAFKA_CFG_MESSAGE_MAX_BYTES: 2000000
-      KAFKA_CFG_MAX_PARTITION_FETCH_BYTES: 2000000
+      KAFKA_CFG_MESSAGE_MAX_BYTES: 1048576
     volumes:
       - type: bind
         source: ${DATA_KAFKA_01_DIR}

--- a/devops/linux/docker/conf/stack/docker-stack-high-1.yml
+++ b/devops/linux/docker/conf/stack/docker-stack-high-1.yml
@@ -107,6 +107,10 @@ services:
       KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_CFG_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_CFG_BROKER_ID: 1
+    # TODO - Later: Research on the appropriate sizes to use for each of these properties. Were added in https://github.com/bitnami/containers/commit/a2984c22221afa766cbf501c30f96a7dc6058653 as a port
+      KAFKA_CFG_MAX_REQUEST_SIZE: 2000000
+      KAFKA_CFG_MESSAGE_MAX_BYTES: 2000000
+      KAFKA_CFG_MAX_PARTITION_FETCH_BYTES: 2000000
     volumes:
       - type: bind
         source: ${DATA_KAFKA_01_DIR}

--- a/devops/linux/docker/conf/stack/docker-stack-high-1.yml
+++ b/devops/linux/docker/conf/stack/docker-stack-high-1.yml
@@ -107,10 +107,7 @@ services:
       KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_CFG_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_CFG_BROKER_ID: 1
-    # TODO - Later: Research on the appropriate sizes to use for each of these properties. Were added in https://github.com/bitnami/containers/commit/a2984c22221afa766cbf501c30f96a7dc6058653 as a port
-      KAFKA_CFG_MAX_REQUEST_SIZE: 2000000
-      KAFKA_CFG_MESSAGE_MAX_BYTES: 2000000
-      KAFKA_CFG_MAX_PARTITION_FETCH_BYTES: 2000000
+      KAFKA_CFG_MESSAGE_MAX_BYTES: 1048576
     volumes:
       - type: bind
         source: ${DATA_KAFKA_01_DIR}

--- a/devops/linux/docker/conf/stack/docker-stack-low-0.yml
+++ b/devops/linux/docker/conf/stack/docker-stack-low-0.yml
@@ -107,6 +107,10 @@ services:
       KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_CFG_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_CFG_BROKER_ID: 1
+    # TODO - Later: Research on the appropriate sizes to use for each of these properties. Were added in https://github.com/bitnami/containers/commit/a2984c22221afa766cbf501c30f96a7dc6058653 as a port
+      KAFKA_CFG_MAX_REQUEST_SIZE: 2000000
+      KAFKA_CFG_MESSAGE_MAX_BYTES: 2000000
+      KAFKA_CFG_MAX_PARTITION_FETCH_BYTES: 2000000
     volumes:
       - type: bind
         source: ${DATA_KAFKA_01_DIR}

--- a/devops/linux/docker/conf/stack/docker-stack-low-0.yml
+++ b/devops/linux/docker/conf/stack/docker-stack-low-0.yml
@@ -107,10 +107,7 @@ services:
       KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_CFG_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_CFG_BROKER_ID: 1
-    # TODO - Later: Research on the appropriate sizes to use for each of these properties. Were added in https://github.com/bitnami/containers/commit/a2984c22221afa766cbf501c30f96a7dc6058653 as a port
-      KAFKA_CFG_MAX_REQUEST_SIZE: 2000000
-      KAFKA_CFG_MESSAGE_MAX_BYTES: 2000000
-      KAFKA_CFG_MAX_PARTITION_FETCH_BYTES: 2000000
+      KAFKA_CFG_MESSAGE_MAX_BYTES: 1048576
     volumes:
       - type: bind
         source: ${DATA_KAFKA_01_DIR}

--- a/devops/linux/docker/conf/stack/docker-stack-low-1.yml
+++ b/devops/linux/docker/conf/stack/docker-stack-low-1.yml
@@ -107,6 +107,10 @@ services:
       KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_CFG_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_CFG_BROKER_ID: 1
+    # TODO - Later: Research on the appropriate sizes to use for each of these properties. Were added in https://github.com/bitnami/containers/commit/a2984c22221afa766cbf501c30f96a7dc6058653 as a port
+      KAFKA_CFG_MAX_REQUEST_SIZE: 2000000
+      KAFKA_CFG_MESSAGE_MAX_BYTES: 2000000
+      KAFKA_CFG_MAX_PARTITION_FETCH_BYTES: 2000000
     volumes:
       - type: bind
         source: ${DATA_KAFKA_01_DIR}

--- a/devops/linux/docker/conf/stack/docker-stack-low-1.yml
+++ b/devops/linux/docker/conf/stack/docker-stack-low-1.yml
@@ -107,10 +107,7 @@ services:
       KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_CFG_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_CFG_BROKER_ID: 1
-    # TODO - Later: Research on the appropriate sizes to use for each of these properties. Were added in https://github.com/bitnami/containers/commit/a2984c22221afa766cbf501c30f96a7dc6058653 as a port
-      KAFKA_CFG_MAX_REQUEST_SIZE: 2000000
-      KAFKA_CFG_MESSAGE_MAX_BYTES: 2000000
-      KAFKA_CFG_MAX_PARTITION_FETCH_BYTES: 2000000
+      KAFKA_CFG_MESSAGE_MAX_BYTES: 1048576
     volumes:
       - type: bind
         source: ${DATA_KAFKA_01_DIR}


### PR DESCRIPTION
**Ticket:** N/A
**Other Related Tickets:** N/A
**Other Related PRS:** N/A

----

## Describe of changes

 Bitnami changed/update their image for version 3,6,1 and in doing so, introduced aa breaking change. This change now required you to pass  additional environment variables, of which `KAFKA_CFG_MESSAGE_MAX_BYTES
` was required. highlighted below 
 
 ```
KAFKA_CFG_MAX_REQUEST_SIZE
KAFKA_CFG_MESSAGE_MAX_BYTES
KAFKA_CFG_MAX_PARTITION_FETCH_BYTES
```

When these variable were not present you get the following stacktrace

```
jempi_kafka-01.1.4s7caieksuja@sush-Dell-G15-Special-Edition-5521    | Exception in thread "main" org.apache.kafka.common.config.ConfigException: Invalid value  for configuration message.max.bytes: Not a number of type INT
jempi_kafka-01.1.4s7caieksuja@sush-Dell-G15-Special-Edition-5521    |         at org.apache.kafka.common.config.ConfigDef.parseType(ConfigDef.java:745)
```

This pull request fixes this by add the environment variables to our stack

## How to test / configure

Start JeMPI, and everything should running normally, including kafka