### PR TITLE
Small performance improvements to the tally methods

### DIFF
--- a/JeMPI_Apps/JeMPI_Controller/src/main/java/org/jembi/jempi/controller/interactions_processor/InteractionProcessorRunner.java
+++ b/JeMPI_Apps/JeMPI_Controller/src/main/java/org/jembi/jempi/controller/interactions_processor/InteractionProcessorRunner.java
@@ -1,6 +1,5 @@
 package org.jembi.jempi.controller.interactions_processor;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jembi.jempi.controller.interactions_processor.lib.range_type.RangeTypeFactory;
 import org.jembi.jempi.libmpi.LibMPI;
 import org.jembi.jempi.shared.libs.interactionProcessor.models.OnNewInteractionInteractionProcessorEnvelope;
@@ -22,27 +21,21 @@ public class InteractionProcessorRunner {
         return new StandardInteractionProcessor(GlobalConstants.DEFAULT_LINKER_GLOBAL_STORE_NAME, interaction, libMPI);
     }
 
-    private static <T> T objectConvertor(final Object value, final Class<T> classToMap) {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.findAndRegisterModules();
-        return mapper.convertValue(value, classToMap);
-    }
     public static void run(final InteractionProcessorEnvelop interactionProcessorEnvelop, final LibMPI libMPI) throws ExecutionException, InterruptedException, InteractionProcessorNotFoundException {
 
         String processorToUse = interactionProcessorEnvelop.processorToUse();
-        Object interactionEnvelop = interactionProcessorEnvelop.interactionEnvelop();
-
         switch (processorToUse) {
             case InteractionProcessorEvents.ON_NEW_INTERACTION:
-                OnNewInteractionInteractionProcessorEnvelope interactionEnvNn = objectConvertor(interactionEnvelop, OnNewInteractionInteractionProcessorEnvelope.class);
+                OnNewInteractionInteractionProcessorEnvelope interactionEnvNn = interactionProcessorEnvelop.newInteractionEnvelope();
                 Interaction interactionNn = interactionEnvNn.interaction();
                 // todo: Rethink the envelope stan. The correct way would be to update the envelope to contain the correct data. This change should be a part of a bigger one
                 getInteractionProcessor(interactionNn, libMPI).onNewInteraction(interactionNn, interactionEnvNn.envelopeStan());
                 return;
             case InteractionProcessorEvents.ON_PROCESS_CANDIDATES:
-                OnProcessCandidatesInteractionProcessorEnvelope interactionEnvOPC = objectConvertor(interactionEnvelop, OnProcessCandidatesInteractionProcessorEnvelope.class);
-                Interaction interactionOPC = interactionEnvOPC.interaction();
-                Float matchThreshold = interactionEnvOPC.matchThreshold();
+                OnProcessCandidatesInteractionProcessorEnvelope interactionOPCEnv = interactionProcessorEnvelop.newProcessCandidatesEnvelope();
+                Interaction interactionOPC = interactionOPCEnv.interaction();
+                Float matchThreshold = interactionOPCEnv.matchThreshold();
+
                 StandardInteractionProcessor processor = (StandardInteractionProcessor) getInteractionProcessor(interactionOPC, libMPI).setRanges(
                         new ArrayList<>(Arrays.asList(
                                 RangeTypeFactory.standardThresholdNotificationRangeBelow(matchThreshold - 0.1F, matchThreshold),

--- a/JeMPI_Apps/JeMPI_LibShared/src/main/java/org/jembi/jempi/shared/libs/interactionProcessor/InteractionProcessorConnector.java
+++ b/JeMPI_Apps/JeMPI_LibShared/src/main/java/org/jembi/jempi/shared/libs/interactionProcessor/InteractionProcessorConnector.java
@@ -15,10 +15,16 @@ import java.util.UUID;
 
 
 public final class InteractionProcessorConnector {
-
+    private static InteractionProcessorConnector instance = null;
+    public static InteractionProcessorConnector getInstance(final String bootstrapperServer) {
+        if (instance == null) {
+            instance = new InteractionProcessorConnector(bootstrapperServer);
+        }
+        return instance;
+    }
     private static final Logger LOGGER = LogManager.getLogger(InteractionProcessorConnector.class);
     private MyKafkaProducer<String, InteractionProcessorEnvelop> kafkaProducer;
-    public InteractionProcessorConnector(final String bootstrapperServer) {
+    private InteractionProcessorConnector(final String bootstrapperServer) {
         kafkaProducer = new MyKafkaProducer<>(bootstrapperServer,
                                 GlobalConstants.TOPIC_INTERACTION_PROCESSOR_CONTROLLER,
                                 new StringSerializer(), new JsonPojoSerializer<>(),
@@ -26,7 +32,7 @@ public final class InteractionProcessorConnector {
     }
 
     private void produceMessage(final InteractionProcessorEnvelop interactionProcessorEnvelop) {
-        kafkaProducer.produceAsync(UUID.randomUUID().toString(),
+        kafkaProducer.produceAsync("interactionProcessorMessage",
                                     interactionProcessorEnvelop,
                                     ((metadata, exception) -> {
                                         if (exception != null) {
@@ -37,10 +43,10 @@ public final class InteractionProcessorConnector {
     }
     public void sendOnNewNotification(final Interaction interaction, final String envelopeStan) {
         produceMessage(new InteractionProcessorEnvelop(InteractionProcessorEvents.ON_NEW_INTERACTION,
-                new OnNewInteractionInteractionProcessorEnvelope(interaction, envelopeStan)));
+                new OnNewInteractionInteractionProcessorEnvelope(interaction, envelopeStan), null));
     }
     public void sendOnProcessCandidates(final Interaction interaction, final String envelopeStan, final Float matchThreshold) {
-        produceMessage(new InteractionProcessorEnvelop(InteractionProcessorEvents.ON_PROCESS_CANDIDATES,
+        produceMessage(new InteractionProcessorEnvelop(InteractionProcessorEvents.ON_PROCESS_CANDIDATES, null,
                 new OnProcessCandidatesInteractionProcessorEnvelope(interaction, envelopeStan, matchThreshold)));
     }
 }

--- a/JeMPI_Apps/JeMPI_LibShared/src/main/java/org/jembi/jempi/shared/libs/interactionProcessor/models/InteractionProcessorEnvelop.java
+++ b/JeMPI_Apps/JeMPI_LibShared/src/main/java/org/jembi/jempi/shared/libs/interactionProcessor/models/InteractionProcessorEnvelop.java
@@ -1,4 +1,6 @@
 package org.jembi.jempi.shared.libs.interactionProcessor.models;
 
-public record InteractionProcessorEnvelop(String processorToUse,  Object interactionEnvelop) {
+public record InteractionProcessorEnvelop(String processorToUse,
+                                          OnNewInteractionInteractionProcessorEnvelope newInteractionEnvelope,
+                                          OnProcessCandidatesInteractionProcessorEnvelope newProcessCandidatesEnvelope) {
 }

--- a/JeMPI_Apps/JeMPI_Linker/src/main/java/org/jembi/jempi/linker/backend/LinkerDWH.java
+++ b/JeMPI_Apps/JeMPI_Linker/src/main/java/org/jembi/jempi/linker/backend/LinkerDWH.java
@@ -118,7 +118,7 @@ public final class LinkerDWH {
          final ExternalLinkRange externalLinkRange,
          final float matchThreshold_, final String envelopeStan) {
 
-      InteractionProcessorConnector interactionProcessorConnector = new InteractionProcessorConnector(AppConfig.KAFKA_BOOTSTRAP_SERVERS);
+      InteractionProcessorConnector interactionProcessorConnector = InteractionProcessorConnector.getInstance(AppConfig.KAFKA_BOOTSTRAP_SERVERS);
 
       interactionProcessorConnector.sendOnNewNotification(interaction, envelopeStan);
       if (!CustomLinkerDeterministic.canApplyLinking(interaction.demographicData())) {


### PR DESCRIPTION
**Ticket:** N/A
**Other Related Tickets:** N/A
**Other Related PRS:** https://github.com/jembi/JeMPI/pull/167

----

## Describe of changes

This change some small performance improvements to the tally logic. It does this by
1. Making the kafka envelope from the linker to the controller a concrete type
2. Making the interaction connector as singleton, making there only be one producer for pushing the messages


## How to test / configure

- Start JeMPI, and everything should running normally
- Repeat the tests found here https://github.com/jembi/JeMPI/pull/167