### PR TITLE
Adding ability to specify namespace when deploying images to a docker repository

### DIFF
--- a/.github/workflows/actions/build-deploy-images/action.yml
+++ b/.github/workflows/actions/build-deploy-images/action.yml
@@ -10,6 +10,8 @@ inputs:
     required: true
   docker-password:
     required: true
+  docker-namespace:
+    required: false
 runs:
   using: 'composite'
   steps:
@@ -23,3 +25,4 @@ runs:
         docker-username: ${{ inputs.docker-username }}
         docker-password: ${{ inputs.docker-password }}
         docker-host: ${{ inputs.docker-host }}
+        docker-namespace: ${{ inputs.docker-namespace }}

--- a/.github/workflows/actions/docker-images-deploy/action.yml
+++ b/.github/workflows/actions/docker-images-deploy/action.yml
@@ -10,6 +10,8 @@ inputs:
     required: true
   docker-password:
     required: true
+  docker-namespace:
+    required: false
 runs:
   using: 'composite'
   steps:
@@ -20,5 +22,6 @@ runs:
             "${{ inputs.docker-push-tag }}" \
             "${{ inputs.docker-host }}" \
             "${{ inputs.docker-username }}" \
-            "${{ inputs.docker-password }}"
+            "${{ inputs.docker-password }}" \
+            "${{ inputs.docker-namespace || 'jembi' }}"
       shell: bash

--- a/.github/workflows/actions/docker-images-deploy/deployDockerImages.sh
+++ b/.github/workflows/actions/docker-images-deploy/deployDockerImages.sh
@@ -5,6 +5,7 @@ push_tag=$2
 registry_url=$3
 username=$4
 password=$5
+namespace=$6
 
 if [ -z "$registry_url" ] || [ -z "$username" ] || [ -z "$password" ]; then
     echo "Docker host details not set. Skipping deploying"
@@ -26,7 +27,7 @@ IMAGE_LIST=$(docker image ls --filter "reference=*:$original_tag" --format "{{.R
 
 for IMAGE in $IMAGE_LIST; do
     IFS=':' read -a image_details <<< "$IMAGE"
-    push_tag_url="$registry_url/$username/${image_details[0]}:$push_tag"
+    push_tag_url="$registry_url/$namespace/${image_details[0]}:$push_tag"
 
     echo "Pushing image: $IMAGE to '$push_tag_url'"
 

--- a/.github/workflows/deploy-images-dockerhub.yml
+++ b/.github/workflows/deploy-images-dockerhub.yml
@@ -52,3 +52,4 @@ jobs:
         docker-host: "docker.io"
         docker-username: ${{ secrets.DOCKER_HUB_USER_NAME }}
         docker-password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+        docker-namespace: ${{ vars.DOCKER_HUB_NAMESPACE }}

--- a/.github/workflows/entry-on-merge.yml
+++ b/.github/workflows/entry-on-merge.yml
@@ -37,3 +37,4 @@ jobs:
         docker-host: ${{ vars.DOCKER_LOCAL_HOST_NAME }}
         docker-username: ${{ secrets.DOCKER_LOCAL_USER_NAME }}
         docker-password: ${{ secrets.DOCKER_LOCAL_PASSWORD }}
+        docker-namespace: ${{ vars.DOCKER_LOCAL_NAMESPACE }}

--- a/.github/workflows/entry-on-release.yml
+++ b/.github/workflows/entry-on-release.yml
@@ -37,3 +37,4 @@ jobs:
         docker-host: "docker.io"
         docker-username: ${{ secrets.DOCKER_HUB_USER_NAME }}
         docker-password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+        docker-namespace: ${{ vars.DOCKER_HUB_NAMESPACE }}


### PR DESCRIPTION
**Ticket:** N/A
**Other Related Tickets:** N/A

----

## Describe of changes

This change adds support for specify the namespace to use when deploying images to a docker repository. 

- In the case of deploying to dockerhub (for the OnRelease, and Deploy images to dockerhub workflows) you need to set the following variable (Setting > Setting and variables > Actions > Variables (tab) > Repository variable)
`DOCKER_HUB_NAMESPACE`
*Note:-* If nothing is set it defaults the namespace to `jembi` 

- When deploying to a local repository you will need to set the following variable
`DOCKER_LOCAL_NAMESPACE`

## How to test / configure

- The best way to test this is to trigger the aforementioned workflow, by creating pull request and merging. This should trigger the appropriate workflows

