### PR TITLE
* Linking new golden record fixed

### DIFF
--- a/JeMPI_Apps/JeMPI_LibAPI/src/main/java/org/jembi/jempi/libapi/Routes.java
+++ b/JeMPI_Apps/JeMPI_LibAPI/src/main/java/org/jembi/jempi/libapi/Routes.java
@@ -130,7 +130,7 @@ public final class Routes {
       return entity(Jackson.unmarshaller(NotificationResolution.class),
               obj -> onComplete(Ask.patchIidNewGidLink(actorSystem,
                                       backEnd,
-                                      obj.newGoldenId(),
+                                      obj.currentGoldenId(),
                                       obj.interactionId()),
                               result -> result.isSuccess()
                                       ? result.get()


### PR DESCRIPTION
**Ticket**: N/A
**Other Related Tickets**: N/A

### **Describe of changes**
___________________________________________________________________________________________________

This PR Includes the bug fix for creating a new golden record and linking a new golden record for a notification. This change includes usage of the `currentGoldenId` request than the `newGoldenId` which didnt exist in the `patchIidNewGidLink` function in the JeMPI_LibAPI

**Change from**

```
 ...
 
            replyTo -> new BackEnd.PatchIidNewGidLinkRequest(
                                                                                             replyTo,
                                                                                             newGoldenId,
                                                                                             patientId,
                                                                                             2.0F),
   ...
```


**Change to** 

```
 ...
 
            replyTo -> new BackEnd.PatchIidNewGidLinkRequest(
                                                                                             replyTo,
                                                                                             currentGoldenId,
                                                                                             patientId,
                                                                                             2.0F),
   ...
```

### **How to test / configure**
___________________________________________________________________________________________________

You may press the "Create new golden record" button on an open notification or the "Link" button on a blocked record in which either a successful message should popup and a redirect to the audit log should happen without an error