### PR TITLE
Jmpi disable create new golden record button

### DIFF
--- a/JeMPI_Apps/JeMPI_UI/src/components/reviewLink/ReviewLink.tsx
+++ b/JeMPI_Apps/JeMPI_UI/src/components/reviewLink/ReviewLink.tsx
@@ -75,6 +75,9 @@ const ReviewLink = () => {
   } = useLinkReview(payload, refineSearchQuery, candidateThreshold)
   const { linkRecords, createNewGoldenRecord } = useRelink()
 
+  const shouldDisableCreateGoldenRecordButton = (): boolean =>
+  !(goldenRecord && goldenRecord?.linkRecords.length > 1);
+
   const mutateNotification = useMutation({
     mutationFn: (request: NotificationRequest) =>
       apiClient.updateNotification(request),
@@ -320,6 +323,7 @@ const ReviewLink = () => {
           <Button
             variant="outlined"
             onClick={() => setIsNewGoldenRecordDialogOpen(true)}
+            disabled={shouldDisableCreateGoldenRecordButton()}
           >
             Create new golden record
           </Button>


### PR DESCRIPTION
### 1. Description of changes

added shouldDisableCreateGoldenRecordButton to create new golden record button

2. How to test/configure

Navigate to http://localhost:3000/notifications
![Create New Golden Record](https://github.com/jembi/JeMPI/assets/92095336/a32dac6a-8284-4823-80a3-890dfd7f4d4e)