### PR TITLE
Spliting linker matching process onto another kafka stream

### DIFF
--- a/JeMPI_Apps/JeMPI_Bootstrapper/src/main/resources/data/kafka/kafkaBootStrapConfig.json
+++ b/JeMPI_Apps/JeMPI_Bootstrapper/src/main/resources/data/kafka/kafkaBootStrapConfig.json
@@ -35,6 +35,13 @@
       "retention_ms": 86400000,
       "segments_bytes": 4194304
     },
+    "JeMPI-interaction-linker-matching": {
+      "topicName": "JeMPI-interaction-linker-matching",
+      "partition": 1,
+      "replications": 1,
+      "retention_ms": 86400000,
+      "segments_bytes": 4194304
+    },
     "JeMPI-mu-controller": {
       "topicName": "JeMPI-mu-controller",
       "partition": 1,

--- a/JeMPI_Apps/JeMPI_LibShared/src/main/java/org/jembi/jempi/shared/models/GlobalConstants.java
+++ b/JeMPI_Apps/JeMPI_LibShared/src/main/java/org/jembi/jempi/shared/models/GlobalConstants.java
@@ -7,6 +7,7 @@ public final class GlobalConstants {
    public static final String TOPIC_INTERACTION_PROCESSOR_CONTROLLER = "JeMPI-interaction-processor-controller";
    public static final String TOPIC_INTERACTION_EM = "JeMPI-interaction-em";
    public static final String TOPIC_INTERACTION_LINKER = "JeMPI-interaction-linker";
+   public static final String TOPIC_INTERACTION_LINKER_MATCHING = "JeMPI-interaction-linker-matching";
    public static final String TOPIC_MU_CONTROLLER = "JeMPI-mu-controller";
    public static final String TOPIC_MU_LINKER = "JeMPI-mu-linker";
    public static final String TOPIC_AUDIT_TRAIL = "JeMPI-audit-trail";

--- a/JeMPI_Apps/JeMPI_Linker/src/main/java/org/jembi/jempi/linker/Ask.java
+++ b/JeMPI_Apps/JeMPI_Linker/src/main/java/org/jembi/jempi/linker/Ask.java
@@ -111,6 +111,17 @@ final class Ask {
                             actorSystem.scheduler());
    }
 
+   static CompletionStage<BackEnd.AsyncMatchInteractionResponse> matchInteraction(
+           final ActorSystem<Void> actorSystem,
+           final ActorRef<BackEnd.Request> backEnd,
+           final String key,
+           final InteractionEnvelop batchInteraction) {
+      return AskPattern.ask(backEnd,
+              replyTo -> new BackEnd.AsyncMatchInteractionRequest(replyTo, key, batchInteraction),
+              java.time.Duration.ofSeconds(60),
+              actorSystem.scheduler());
+   }
+
    static CompletionStage<BackEnd.RunStartStopHooksResponse> runStartEndHooks(
            final ActorSystem<Void> actorSystem,
            final ActorRef<BackEnd.Request> backEnd,

--- a/JeMPI_Apps/JeMPI_Linker/src/main/java/org/jembi/jempi/linker/SPInteractions.java
+++ b/JeMPI_Apps/JeMPI_Linker/src/main/java/org/jembi/jempi/linker/SPInteractions.java
@@ -14,6 +14,7 @@ import org.jembi.jempi.AppConfig;
 import org.jembi.jempi.libmpi.MpiGeneralError;
 import org.jembi.jempi.linker.backend.BackEnd;
 import org.jembi.jempi.shared.models.CustomMU;
+import org.jembi.jempi.shared.models.GlobalConstants;
 import org.jembi.jempi.shared.models.InteractionEnvelop;
 import org.jembi.jempi.shared.serdes.JsonPojoDeserializer;
 import org.jembi.jempi.shared.serdes.JsonPojoSerializer;
@@ -52,7 +53,6 @@ public final class SPInteractions {
 
       if (interactionEnvelop.contentType() == InteractionEnvelop.ContentType.BATCH_START_SENTINEL
               || interactionEnvelop.contentType() == BATCH_END_SENTINEL) {
-         forwardtoMatching
          final var completableFuture = Ask.runStartEndHooks(system, backEnd, key, interactionEnvelop).toCompletableFuture();
          try {
             List<MpiGeneralError> hookErrors = completableFuture.get(65, TimeUnit.SECONDS).hooksResults();
@@ -110,7 +110,7 @@ public final class SPInteractions {
               new JsonPojoDeserializer<>(InteractionEnvelop.class));
       final StreamsBuilder streamsBuilder = new StreamsBuilder();
       final KStream<String, InteractionEnvelop> matchStream =
-              streamsBuilder.stream(topic, Consumed.with(stringSerde, interactionEnvelopSerde));
+              streamsBuilder.stream(GlobalConstants.TOPIC_NOTIFICATIONS, Consumed.with(stringSerde, interactionEnvelopSerde));
       matchStream.foreach((key, matchEnvelop) -> {
          matchPatient(system, backEnd, key, matchEnvelop);
          if (matchEnvelop.contentType() == BATCH_END_SENTINEL) {

--- a/JeMPI_Apps/JeMPI_Linker/src/main/java/org/jembi/jempi/linker/SPInteractions.java
+++ b/JeMPI_Apps/JeMPI_Linker/src/main/java/org/jembi/jempi/linker/SPInteractions.java
@@ -97,10 +97,11 @@ public final class SPInteractions {
       if (interactionEnvelop.contentType() != BATCH_INTERACTION) {
          return;
       }
+
       final var completableFuture = Ask.matchInteraction(system, backEnd, key, interactionEnvelop).toCompletableFuture();
       try {
          final var reply = completableFuture.get(65, TimeUnit.SECONDS);
-         if (reply.linkInfo() == null) {
+         if (!reply.matched()) {
             LOGGER.error("BACK END RESPONSE(ERROR)");
          }
       } catch (InterruptedException | ExecutionException | TimeoutException ex) {

--- a/JeMPI_Apps/JeMPI_Linker/src/main/java/org/jembi/jempi/linker/backend/BackEnd.java
+++ b/JeMPI_Apps/JeMPI_Linker/src/main/java/org/jembi/jempi/linker/backend/BackEnd.java
@@ -238,17 +238,16 @@ public final class BackEnd extends AbstractBehavior<BackEnd.Request> {
             return Behaviors.same();
          });
       }
-      // to-do: Consider if LinkInfo is nevessary
       final var linkInfo =
               LinkerDWH.matchInteraction(libMPI,
                       req.batchInteraction.interaction(),
                       null,
                       AppConfig.LINKER_MATCH_THRESHOLD,
                       req.batchInteraction.stan());
-      if (linkInfo.isLeft()) {
-         req.replyTo.tell(new AsyncMatchInteractionResponse(linkInfo.getLeft()));
+      if (linkInfo.isRight()) {
+         req.replyTo.tell(new AsyncMatchInteractionResponse(true));
       } else {
-         req.replyTo.tell(new AsyncMatchInteractionResponse(null));
+         req.replyTo.tell(new AsyncMatchInteractionResponse(false));
       }
       return Behaviors.withTimers(timers -> {
          timers.startSingleTimer(SINGLE_TIMER_TIMEOUT_KEY, TeaTimeRequest.INSTANCE, Duration.ofSeconds(10));
@@ -389,7 +388,7 @@ public final class BackEnd extends AbstractBehavior<BackEnd.Request> {
            InteractionEnvelop batchInteraction) implements Request {
    }
 
-   public record AsyncMatchInteractionResponse(LinkInfo linkInfo) implements Response {
+   public record AsyncMatchInteractionResponse(Boolean matched) implements Response {
    }
 
    public record RunStartStopHooksRequest(

--- a/JeMPI_Apps/JeMPI_Linker/src/main/java/org/jembi/jempi/linker/backend/BackEnd.java
+++ b/JeMPI_Apps/JeMPI_Linker/src/main/java/org/jembi/jempi/linker/backend/BackEnd.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
@@ -37,6 +38,8 @@ public final class BackEnd extends AbstractBehavior<BackEnd.Request> {
    private static final Logger LOGGER = LogManager.getLogger(BackEnd.class);
    private static final String SINGLE_TIMER_TIMEOUT_KEY = "SingleTimerTimeOutKey";
    static MyKafkaProducer<String, Notification> topicNotifications;
+
+   static MyKafkaProducer<String, InteractionEnvelop> matchingInteractions;
    private final Executor ec;
    private LibMPI libMPI = null;
 
@@ -52,6 +55,12 @@ public final class BackEnd extends AbstractBehavior<BackEnd.Request> {
                                                  new StringSerializer(),
                                                  new JsonPojoSerializer<>(),
                                                  AppConfig.KAFKA_CLIENT_ID_NOTIFICATIONS);
+
+      matchingInteractions = new MyKafkaProducer<>(AppConfig.KAFKA_BOOTSTRAP_SERVERS,
+              GlobalConstants.TOPIC_INTERACTION_LINKER_MATCHING,
+              new StringSerializer(),
+              new JsonPojoSerializer<>(),
+              AppConfig.KAFKA_CLIENT_ID_NOTIFICATIONS);
    }
 
    private BackEnd(
@@ -144,8 +153,10 @@ public final class BackEnd extends AbstractBehavior<BackEnd.Request> {
       return Behaviors.same();
    }
 
-   private Behavior<Request> runStartStopHooks(final RunStartStopHooksRequest req) {
+   private Behavior<Request> runStartStopHooks(final RunStartStopHooksRequest req) throws ExecutionException, InterruptedException {
       List<MpiGeneralError> hookRunErrors = List.of();
+
+      matchingInteractions.produceSync(req.key, req.batchInteraction);
 
       if (req.batchInteraction.contentType() == BATCH_START_SENTINEL) {
          hookRunErrors = libMPI.beforeLinkingHook();
@@ -172,7 +183,8 @@ public final class BackEnd extends AbstractBehavior<BackEnd.Request> {
                                                          request.link.matchThreshold() == null
                                                                ? AppConfig.LINKER_MATCH_THRESHOLD
                                                                : request.link.matchThreshold(),
-                                                         request.link.stan());
+                                                         request.link.stan(),
+                                                         null);
       request.replyTo.tell(new SyncLinkInteractionResponse(request.link.stan(),
                                                            listLinkInfo.isLeft()
                                                                  ? listLinkInfo.getLeft()
@@ -183,7 +195,7 @@ public final class BackEnd extends AbstractBehavior<BackEnd.Request> {
       return Behaviors.same();
    }
 
-   private Behavior<Request> asyncLinkInteractionHandler(final AsyncLinkInteractionRequest req) {
+   private Behavior<Request> asyncLinkInteractionHandler(final AsyncLinkInteractionRequest req) throws ExecutionException, InterruptedException {
       if (req.batchInteraction.contentType() != InteractionEnvelop.ContentType.BATCH_INTERACTION) {
          return Behaviors.withTimers(timers -> {
             timers.startSingleTimer(SINGLE_TIMER_TIMEOUT_KEY, TeaTimeRequest.INSTANCE, Duration.ofSeconds(5));
@@ -191,12 +203,22 @@ public final class BackEnd extends AbstractBehavior<BackEnd.Request> {
             return Behaviors.same();
          });
       }
+
       final var linkInfo =
             LinkerDWH.linkInteraction(libMPI,
                                       req.batchInteraction.interaction(),
                                       null,
                                       AppConfig.LINKER_MATCH_THRESHOLD,
-                                      req.batchInteraction.stan());
+                                      req.batchInteraction.stan(),
+                                      (final Interaction interaction) -> {
+                                         try {
+                                            BackEnd.matchingInteractions.produceSync(req.key, req.batchInteraction);
+                                         } catch (ExecutionException e) {
+                                            throw new RuntimeException(e);
+                                         } catch (InterruptedException e) {
+                                            throw new RuntimeException(e);
+                                         }
+                                      });
       if (linkInfo.isLeft()) {
          req.replyTo.tell(new AsyncLinkInteractionResponse(linkInfo.getLeft()));
       } else {

--- a/JeMPI_Apps/JeMPI_Linker/src/main/java/org/jembi/jempi/linker/backend/LinkerDWH.java
+++ b/JeMPI_Apps/JeMPI_Linker/src/main/java/org/jembi/jempi/linker/backend/LinkerDWH.java
@@ -17,6 +17,7 @@ import org.jembi.jempi.shared.utils.AppUtils;
 
 import java.util.*;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -170,7 +171,8 @@ public final class LinkerDWH {
          final Interaction interaction,
          final ExternalLinkRange externalLinkRange,
          final float matchThreshold_,
-         final String envelopStan) {
+         final String envelopStan,
+         final Consumer<Interaction> forwarder) {
 
 //      if (LOGGER.isTraceEnabled()) {
 //         LOGGER.trace("{}", envelopStan);
@@ -188,7 +190,12 @@ public final class LinkerDWH {
       }
 
       if (!CustomLinkerDeterministic.canApplyLinking(interaction.demographicData())) {
-         sendKafkaTopic();
+         if (forwarder != null) {
+            forwarder.accept(interaction);
+            return Either.right(List.of());
+         } else {
+            return matchInteraction(libMPI, interaction, externalLinkRange, matchThreshold_, envelopStan);
+         }
       } else {
          LinkInfo linkInfo = null;
          final List<ExternalLinkCandidate> externalLinkCandidateList = new ArrayList<>();


### PR DESCRIPTION
**Ticket:** N/A
**Other Related Tickets:** N/A

----

## Describe of changes

This change optimizes JeMPI linking process, by splitting up the matching logic to another stream, which only start once linking has complete

**In detail**
When linking, the linker first tries to determines if it can link by checking if the required (linking) variables are present in the interaction (These required variable, are configured in the reference-config under `rules.link`). If so preceding to link based on the deterministic  / probabilistic rules configured.

Currently (before this changes), if the required fields where not there it would try to match using the renaming (given that you have configured matching rules) 

During linking, this would slow down the process, and matching uses fuzzy searching

This change, pushes on the interactions that need matching to a new stream. Once  linking is done for an upload, it then processes the linking queue

**Note:-** 

Although in the ideal case this would speed up JeMPI, the configuration, and rules set is a great determiner. For instance, if your linking rules are probabilistic, using fuzzy searching, this will provide very little benefit. This change assumes you configure you reference-config in such a way that your link rule are deterministic (or non-complex probabilistic)  and then the more probabilistic/fuzzy search based be in you notification rules

## How to test

- Run the configurator using this sample config 
  - This config will set the following 
    - `PROBABILISTIC_DO_LINKING` in JeMPI_Apps/JeMPI_Linker/src/main/java/org/jembi/jempi/linker/backend/CustomLinkerProbabilistic.java to `false`
    - `DETERMINISTIC_DO_MATCHING` in JeMPI_Apps/JeMPI_Linker/src/main/java/org/jembi/jempi/linker/backend/CustomLinkerProbabilistic.java to `true`

- upload/add this sample csv (which has same missing fields) 

- In you logs for the linker you should see something like

```
[INFO ] 2024-03-14 04:19:03.445 SPInteractions:158 - KafkaStreams started
...
[INFO ] 2024-03-14 04:19:18.308 SPInteractions:68 - SPInteractions Stream Processor -> Starting linking for tag 'sample2Streams2'
[DEBUG] 2024-03-14 04:19:18.666 LinkerDWH:209 - 2024/03/14 04:19:16:0000002 : 0
[DEBUG] 2024-03-14 04:19:18.908 LinkerDWH:209 - 2024/03/14 04:19:16:0000003 : 0
.....
[INFO ] 2024-03-14 04:19:20.112 SPInteractions:71 - SPInteractions Stream Processor -> Ended linking for tag 'sample2Streams2'
[INFO ] 2024-03-14 04:19:20.116 SPInteractions:142 - SPInteractions Stream Processor -> Starting matching for tag 'sample2Streams2'
[DEBUG] 2024-03-14 04:19:23.189 LinkerDWH:131 - Match Candidates 0 
[INFO ] 2024-03-14 04:19:23.190 LinkerDWH:138 - MATCH NOTIFICATION NO CANDIDATE
{"givenName":"","familyName":"","gender":"female","dob":"19791014","city":"maceo","phoneNumber":"","nationalId":""}
[DEBUG] 2024-03-14 04:19:23.201 LinkerDWH:131 - Match Candidates 0 
[INFO ] 2024-03-14 04:19:23.202 LinkerDWH:138 - MATCH NOTIFICATION NO CANDIDATE
{"givenName":"","familyName":"","gender":"female","dob":"19561006","city":"castlerea","phoneNumber":"","nationalId":""}
[DEBUG] 2024-03-14 04:19:23.214 LinkerDWH:131 - Match Candidates 0 
[INFO ] 2024-03-14 04:19:23.214 LinkerDWH:138 - MATCH NOTIFICATION NO CANDIDATE
{"givenName":"","familyName":"","gender":"female","dob":"19980504","city":"bolikhan","phoneNumber":"","nationalId":""}
[INFO ] 2024-03-14 04:19:23.215 SPInteractions:125 - SPInteractions Stream Processor -> Ended matching for tag 'sample2Streams2'
[INFO ] 2024-03-14 04:19:23.215 SPInteractions:167 - SPInteractions Stream Processor -> Closing matching processor

```

