### PR TITLE
Jmpi-disabled-on-click-for-closed-notifications

### DIFF
--- a/JeMPI_Apps/JeMPI_UI/src/components/notificationWorklist/NotificationWorklist.tsx
+++ b/JeMPI_Apps/JeMPI_UI/src/components/notificationWorklist/NotificationWorklist.tsx
@@ -175,7 +175,9 @@ const NotificationWorklist = () => {
                 filterModel={filterModel}
                 loading={isLoading}
                 onFilterModelChange={debounce(onFilterChange, 3000)}
-                onRowDoubleClick={params =>
+                onRowDoubleClick={params => {
+                  if (params.row.state === NotificationState.CLOSED.toString()) return;
+
                   navigate(
                     {
                       pathname: 'match-details'
@@ -192,8 +194,8 @@ const NotificationWorklist = () => {
                         }
                       }
                     }
-                  )
-                }
+                  );
+                }}
               />
             )}
           </Box>


### PR DESCRIPTION
### 1. Description of changes
Added  early return when selected row has status closed

### 2. How to test
Navigate to notification work-list
select/ double click on a closed notification