### PR TITLE
Cu 86bzhmv6z custom aux gid not accepted during golden record creation or restoration

### DIFF
--- a/JeMPI_Apps/JeMPI_EM_Scala/src/main/scala/org/jembi/jempi/em/config/Config.scala
+++ b/JeMPI_Apps/JeMPI_EM_Scala/src/main/scala/org/jembi/jempi/em/config/Config.scala
@@ -36,7 +36,10 @@ case class Source(
     interactionField: Option[String]
 )
 
-case class Generate(func: String)
+case class Generate(
+    func: String,
+    interactionField: Option[String] = None
+)
 
 case class ProbabilisticMetaData(
     comparison: String,

--- a/JeMPI_Apps/JeMPI_LibShared/src/main/java/org/jembi/jempi/shared/config/input/Generate.java
+++ b/JeMPI_Apps/JeMPI_LibShared/src/main/java/org/jembi/jempi/shared/config/input/Generate.java
@@ -3,5 +3,11 @@ package org.jembi.jempi.shared.config.input;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record Generate(String func) {
+public record Generate(
+    String func,
+    String interactionField) {
+
+    public Generate(final String func) {
+        this(func, null);
+    }
 }

--- a/JeMPI_Apps/JeMPI_LibShared/src/main/java/org/jembi/jempi/shared/models/AuxGoldenRecordData.java
+++ b/JeMPI_Apps/JeMPI_LibShared/src/main/java/org/jembi/jempi/shared/models/AuxGoldenRecordData.java
@@ -60,7 +60,7 @@ public record AuxGoldenRecordData(
       objectNode.put(FieldsConfig.GOLDEN_RECORD_AUX_AUTO_UPDATE_ENABLED_FIELD_NAME_CC,
                      auxGoldenRecordData.auxAutoUpdateEnabled.booleanValue());
       auxGoldenRecordData.auxUserFields.forEach(field -> {
-        if (field.ccTag != null && !field.ccTag.isEmpty()) {
+         if (field.ccTag != null && !field.ccTag.isEmpty()) {
             objectNode.put(field.ccTag, field.value);
          }
       });

--- a/JeMPI_Apps/JeMPI_LibShared/src/main/java/org/jembi/jempi/shared/models/AuxGoldenRecordData.java
+++ b/JeMPI_Apps/JeMPI_LibShared/src/main/java/org/jembi/jempi/shared/models/AuxGoldenRecordData.java
@@ -28,8 +28,7 @@ public record AuxGoldenRecordData(
                  .stream()
                  .map(auxGoldenRecordUserField -> new AuxGoldenRecordUserField(
                        auxGoldenRecordUserField.ccName(),
-                       (auxGoldenRecordUserField.source()
-                                                .interactionField() != null)
+                       (auxGoldenRecordUserField.source().interactionField() != null)
                              ? auxInteractionData.auxUserFields().stream()
                                                  .filter(auxInteractionUserField ->
                                                                auxInteractionUserField.scTag()
@@ -39,18 +38,29 @@ public record AuxGoldenRecordData(
                                                  .toList()
                                                  .getFirst().value()
                              : auxGoldenRecordUserField.source().generate() != null
-                                   ? AppUtils.applyFunction(auxGoldenRecordUserField.source().generate().func())
+                                   ? (auxGoldenRecordUserField.source().generate().interactionField() != null
+                                         ? AppUtils.defaultIfFalsy(auxInteractionData.auxUserFields().stream()
+                                                             .filter(auxInteractionUserField ->
+                                                                   auxInteractionUserField.scTag()
+                                                                                          .equals(
+                                                                                                auxGoldenRecordUserField.source()
+                                                                                                                        .generate()
+                                                                                                                        .interactionField()))
+                                                             .toList()
+                                                             .getFirst().value(), AppUtils.applyFunction(auxGoldenRecordUserField.source().generate().func()))
+                                         : AppUtils.applyFunction(auxGoldenRecordUserField.source().generate().func()))
                                    : null))
                  .toList());
    }
 
+   
    public static JsonNode fromAuxGoldenRecordData(final AuxGoldenRecordData auxGoldenRecordData) {
       final var objectNode = OBJECT_MAPPER.createObjectNode();
       objectNode.put(FieldsConfig.GOLDEN_RECORD_AUX_DATE_CREATED_FIELD_NAME_CC, auxGoldenRecordData.auxDateCreated.toString());
       objectNode.put(FieldsConfig.GOLDEN_RECORD_AUX_AUTO_UPDATE_ENABLED_FIELD_NAME_CC,
                      auxGoldenRecordData.auxAutoUpdateEnabled.booleanValue());
       auxGoldenRecordData.auxUserFields.forEach(field -> {
-         if (field.ccTag != null && !field.ccTag.isEmpty()) {
+        if (field.ccTag != null && !field.ccTag.isEmpty()) {
             objectNode.put(field.ccTag, field.value);
          }
       });

--- a/JeMPI_Apps/JeMPI_LibShared/src/main/java/org/jembi/jempi/shared/utils/AppUtils.java
+++ b/JeMPI_Apps/JeMPI_LibShared/src/main/java/org/jembi/jempi/shared/utils/AppUtils.java
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.*;
 import java.time.LocalDateTime;
@@ -21,7 +19,6 @@ public final class AppUtils implements Serializable {
    public static final ObjectMapper OBJECT_MAPPER =
          new ObjectMapper().disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS).registerModule(new JavaTimeModule());
 
-   private static final Logger LOGGER = LogManager.getLogger(AppUtils.class);
    @Serial
    private static final long serialVersionUID = 1L;
    static Long autoIncrement = 0L;
@@ -53,6 +50,29 @@ public final class AppUtils implements Serializable {
 
    public static boolean isNullOrEmpty(final Map<?, ?> m) {
       return m == null || m.isEmpty();
+   }
+
+   public static <T> T defaultIfFalsy(final T value, final T defaultValue) {
+      // Similar to Objects.requireNonNullElse but for broader "falsy" values
+      if (value == null) {
+          return defaultValue;
+      }
+      if (value instanceof String && ((String) value).isEmpty()) {
+          return defaultValue;
+      }
+      if (value instanceof Number && ((Number) value).doubleValue() == 0) {
+          return defaultValue;
+      }
+      if (value instanceof Boolean && !((Boolean) value)) {
+          return defaultValue;
+      }
+      if (value instanceof Collection && ((Collection<?>) value).isEmpty()) {
+         return defaultValue;
+      }
+      if (value.getClass().isArray() && java.lang.reflect.Array.getLength(value) == 0) {
+         return defaultValue;
+      }
+      return value;
    }
 
    public static String quotedValue(final String field) {

--- a/devops/linux/docker/data-config/config-reference-link-dp.json
+++ b/devops/linux/docker/data-config/config-reference-link-dp.json
@@ -26,6 +26,15 @@
           "func": "AppUtils::autoGenerateId"
         }
       }
+    },
+    {
+      "fieldName": "aux_gid",
+      "fieldType": "String",
+      "source": {
+        "generate": {
+          "func": "AppUtils::autoGenerateId"
+        }
+      }
     }
   ],
   "auxGoldenRecordFields": [
@@ -50,7 +59,8 @@
       "fieldType": "String",
       "source": {
         "generate": {
-          "func": "AppUtils::autoGenerateId"
+          "func": "AppUtils::autoGenerateId",
+          "interactionField": "aux_gid"
         }
       }
     }


### PR DESCRIPTION
@MatthewErispe I think the logic needs a sanity check. Do you see any potential knock-on effects of the change to the java and scala "Generate" inputs? Seems safe from what I see.

And this "interactionField" argument added to the "generate" prop:
`   {
      "fieldName": "aux_gid",
      "fieldType": "String",
      "source": {
        "generate": {
          "func": "AppUtils::autoGenerateId",
          **"interactionField": "aux_gid"**
        }
      }
    }`

We could make this more generic, like an "args" object, if the future scope of "generate > func" is likely to expand? Could introduce type safety issues doing it that way so just checking what you think...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `interactionField` in various components for enhanced field mapping and data population logic.
  - Added `defaultIfFalsy` method for handling default values in utilities.

- **Refactor**
  - Improved constructor logic in `AuxGoldenRecordData` to handle new interaction field conditions.

- **Chores**
  - Cleaned up unused logging imports and declarations in utility components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->