### PR TITLE
refactored blocking content

### DIFF
--- a/JeMPI_Apps/JeMPI_UI/src/pages/settings/Settings.tsx
+++ b/JeMPI_Apps/JeMPI_UI/src/pages/settings/Settings.tsx
@@ -13,7 +13,7 @@ import { CustomTabPanel, a11yProps } from './deterministic/BasicTabs'
 import { Configuration } from 'types/Configuration'
 import { generateId } from 'utils/helpers'
 import Probabilistic from './probabilistic/Probabilistic'
-import { useConfig } from 'hooks/useConfig';
+import { useConfig } from 'hooks/useConfig'
 import { useSnackbar } from 'notistack'
 
 const Settings = () => {
@@ -24,19 +24,19 @@ const Settings = () => {
       ? generateId(JSON.parse(storedData))
       : ({} as Configuration)
   })
-  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [isSaving, setIsSaving] = useState<boolean>(false)
 
-  const { apiClient } = useConfig();
+  const { apiClient } = useConfig()
 
   const handleChange = (event: SyntheticEvent, newValue: number) => {
-    setValue(newValue);
-  };
+    setValue(newValue)
+  }
   const { enqueueSnackbar } = useSnackbar()
 
   const handleSave = async () => {
-    setIsSaving(true);
-    const response = await apiClient.saveConfiguration();
-    setIsSaving(false);
+    setIsSaving(true)
+    const response = await apiClient.saveConfiguration()
+    setIsSaving(false)
     if (response && response.response === 'ok') {
       enqueueSnackbar(`Successfully saved configuration`, {
         variant: 'success'
@@ -46,9 +46,9 @@ const Settings = () => {
       enqueueSnackbar(`Error saving configuration`, {
         variant: 'error'
       })
-      console.log('handleSave error', response.data);
+      console.log('handleSave error', response.data)
     }
-  };
+  }
 
   useEffect(() => {
     const handleStorageChange = (event: StorageEvent) => {
@@ -124,28 +124,25 @@ const Settings = () => {
             <Typography variant="h5" sx={{ py: 3 }}>
               Setup properties that are unique to the golden record
             </Typography>
-            <UniqueToGR/>
+            <UniqueToGR />
           </CustomTabPanel>
           <CustomTabPanel value={value} index={2}>
             <Typography variant="h5" sx={{ py: 3 }}>
               Setup properties that are unique to the interaction
             </Typography>
-            <UniqueToInteraction/>
+            <UniqueToInteraction />
           </CustomTabPanel>
           <CustomTabPanel value={value} index={3}>
             <Typography variant="h5" sx={{ py: 3 }}>
               Setup properties for Golden record lists
             </Typography>
-            <GoldenRecordLists/>
+            <GoldenRecordLists />
           </CustomTabPanel>
           <CustomTabPanel value={value} index={4}>
             <Deterministic />
           </CustomTabPanel>
           <CustomTabPanel value={value} index={5}>
-            <Blocking
-              demographicData={configurationData.demographicFields}
-              rules={configurationData?.rules || {}}
-            />
+            <Blocking />
           </CustomTabPanel>
           <CustomTabPanel value={value} index={6}>
             <Typography variant="h5" sx={{ py: 3 }}>
@@ -159,10 +156,10 @@ const Settings = () => {
               <Button variant="outlined" color="secondary">Set to Reference</Button> */}
             </Box>
             <Box>
-              <Button 
-                variant="contained" 
-                color="primary" 
-                onClick={handleSave} 
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={handleSave}
                 disabled={isSaving}
               >
                 {isSaving ? 'Saving...' : 'Save'}

--- a/JeMPI_Apps/JeMPI_UI/src/pages/settings/blocking/Blocking.tsx
+++ b/JeMPI_Apps/JeMPI_UI/src/pages/settings/blocking/Blocking.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react'
 import { Field, Rule } from 'types/Configuration'
 import { a11yProps, CustomTabPanel } from '../deterministic/BasicTabs'
 import BlockingContent from './BlockingContent'
+import { useConfiguration } from 'hooks/useUIConfiguration'
 
 interface BlockingProps {
   demographicData: Field[]
@@ -20,14 +21,16 @@ interface BlockingProps {
   }
 }
 
-const Blocking = ({ demographicData = [], rules = {} }: BlockingProps) => {
+const Blocking = () => {
   const [value, setValue] = useState(0)
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue)
   }
+  const { configuration, setConfiguration } = useConfiguration()
 
-  const matchNotificationRules = rules.matchNotification?.probabilistic ?? []
-  const linkingRules = rules.link?.probabilistic ?? []
+  const matchNotificationRules =
+    configuration?.rules.matchNotification?.probabilistic ?? []
+  const linkingRules = configuration?.rules.link?.probabilistic ?? []
 
   return (
     <Card sx={{ minWidth: 275 }}>
@@ -50,14 +53,12 @@ const Blocking = ({ demographicData = [], rules = {} }: BlockingProps) => {
           </Tabs>
           <CustomTabPanel value={value} index={0}>
             <BlockingContent
-              demographicData={demographicData}
               hasUndefinedRule={linkingRules.length === 0}
               linkingRules={{ link: { probabilistic: linkingRules } }}
             />
           </CustomTabPanel>
           <CustomTabPanel value={value} index={1}>
             <BlockingContent
-              demographicData={demographicData}
               hasUndefinedRule={matchNotificationRules.length === 0}
               linkingRules={{
                 matchNotification: { probabilistic: matchNotificationRules }

--- a/JeMPI_Apps/JeMPI_UI/src/test/settings/BlockingContent.test.tsx
+++ b/JeMPI_Apps/JeMPI_UI/src/test/settings/BlockingContent.test.tsx
@@ -11,8 +11,6 @@ const queryClient = new QueryClient({
     queries: {}
   }
 })
-
-const demographicData: any = mockData.configuration.demographicFields
 const linkingRules: any = mockData.configuration.rules
 
 describe('BlockingContent Component', () => {
@@ -22,7 +20,6 @@ describe('BlockingContent Component', () => {
         <BrowserRouter>
           <ConfigProvider>
             <BlockingContent
-              demographicData={demographicData}
               hasUndefinedRule={false}
               linkingRules={linkingRules}
               handleAddRule={jest.fn()}
@@ -41,7 +38,6 @@ describe('BlockingContent Component', () => {
         <BrowserRouter>
           <ConfigProvider>
             <BlockingContent
-              demographicData={demographicData}
               hasUndefinedRule={false}
               linkingRules={linkingRules}
               handleAddRule={jest.fn()}
@@ -67,7 +63,6 @@ describe('BlockingContent Component', () => {
         <BrowserRouter>
           <ConfigProvider>
             <BlockingContent
-              demographicData={demographicData}
               hasUndefinedRule={false}
               linkingRules={linkingRules}
               handleAddRule={jest.fn()}
@@ -92,7 +87,6 @@ describe('BlockingContent Component', () => {
         <BrowserRouter>
           <ConfigProvider>
             <BlockingContent
-              demographicData={demographicData}
               hasUndefinedRule={false}
               linkingRules={linkingRules}
               handleAddRule={handleAddRuleMock}
@@ -117,7 +111,6 @@ describe('BlockingContent Component', () => {
         <BrowserRouter>
           <ConfigProvider>
             <BlockingContent
-              demographicData={demographicData}
               hasUndefinedRule={false}
               linkingRules={linkingRules}
               handleAddRule={jest.fn}
@@ -141,7 +134,6 @@ describe('BlockingContent Component', () => {
         <BrowserRouter>
           <ConfigProvider>
             <BlockingContent
-              demographicData={demographicData}
               hasUndefinedRule={false}
               linkingRules={linkingRules}
               handleAddRule={jest.fn}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated `Blocking` component to use `useConfiguration` hook for accessing configuration data.
  - Simplified `BlockingContent` component by removing `demographicData` from props and adjusting functions to use `configuration` object.
  
- **Style**
  - Removed unnecessary semicolons and adjusted code formatting in `Settings` and `Blocking` components.

- **Tests**
  - Updated `BlockingContent` tests to reflect the removal of `demographicData` prop and ensure consistency with the new implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->